### PR TITLE
Configure `release-jobs-syncer` to use the correct fork

### DIFF
--- a/release-jobs-syncer/main.go
+++ b/release-jobs-syncer/main.go
@@ -32,7 +32,7 @@ import (
 
 const (
 	org  = "knative"
-	repo = "test-infra"
+	repo = "infra"
 	// PRHead is branch name where the changes occur
 	PRHead = "releasebranch"
 	// PRBase is the branch name where PR targets


### PR DESCRIPTION
/cc @kvmware 

Last code change to get release-jobs-syncer to work on the new repo.